### PR TITLE
Add info-level logging for remember-me token lifecycle

### DIFF
--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentRememberMeTokenRepositoryImpl.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentRememberMeTokenRepositoryImpl.java
@@ -4,6 +4,7 @@ import static run.halo.app.extension.ExtensionUtil.defaultSort;
 import static run.halo.app.extension.index.query.Queries.equal;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 import run.halo.app.core.extension.RememberMeToken;
@@ -17,6 +18,7 @@ import run.halo.app.infra.ReactiveExtensionPaginatedOperatorImpl;
  *
  * @see RememberMeToken
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 class PersistentRememberMeTokenRepositoryImpl implements PersistentRememberMeTokenRepository {
@@ -40,6 +42,7 @@ class PersistentRememberMeTokenRepositoryImpl implements PersistentRememberMeTok
 
     @Override
     public Mono<Void> removeUserTokens(String username) {
+        log.info("Removing all remember-me tokens for user '{}'", username);
         var listOptions =
                 ListOptions.builder().andQuery(equal("spec.username", username)).build();
         return paginatedOperator
@@ -49,6 +52,7 @@ class PersistentRememberMeTokenRepositoryImpl implements PersistentRememberMeTok
 
     @Override
     public Mono<Void> removeToken(String series) {
+        log.info("Removing remember-me token for series '{}'", series);
         return getTokenExtensionForSeries(series).flatMap(client::delete).then();
     }
 

--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/PersistentTokenBasedRememberMeServices.java
@@ -100,16 +100,29 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
         }
         var presentedSeries = cookieTokens[0];
         var presentedToken = cookieTokens[1];
+        log.info("Processing remember-me auto-login for series '{}'", presentedSeries);
         return this.tokenRepository
                 .getTokenForSeries(presentedSeries)
-                .switchIfEmpty(Mono.error(() -> new RememberMeAuthenticationException(
-                        "No persistent token found for series id: " + presentedSeries)))
+                .switchIfEmpty(Mono.error(() -> {
+                    log.info("No remember-me token found for series '{}'", presentedSeries);
+                    return new RememberMeAuthenticationException(
+                            "No persistent token found for series id: " + presentedSeries);
+                }))
+                .doOnNext(token -> log.info(
+                        "Found remember-me token for user '{}', series '{}', lastUsed={}, " + "tokenMatch={}",
+                        token.getSpec().getUsername(),
+                        token.getSpec().getSeries(),
+                        token.getSpec().getLastUsed(),
+                        Objects.equals(token.getSpec().getTokenValue(), presentedToken)))
                 .delayUntil(token -> validateDevice(exchange, token))
                 .delayUntil(token -> {
                     if (!Objects.equals(token.getSpec().getTokenValue(), presentedToken)) {
                         if (isTokenStolen(token, presentedToken)) {
-                            log.error(
-                                    "Possible cookie theft detected for user '{}', series '{}'",
+                            log.info(
+                                    "Cookie theft detected for user '{}', series '{}': "
+                                            + "presentedToken does not match stored token "
+                                            + "and is outside grace period or does not match previous token. "
+                                            + "Removing all tokens for this user.",
                                     token.getSpec().getUsername(),
                                     token.getSpec().getSeries());
                             return this.tokenRepository
@@ -118,12 +131,17 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                                 Invalid remember-me token (Series/token) mismatch. \
                                 Implies previous cookie theft attack.""")));
                         }
-                        log.debug(
-                                "Token mismatch but within grace period for user '{}', series '{}'",
+                        log.info(
+                                "Token mismatch within grace period for user '{}', series '{}'",
                                 token.getSpec().getUsername(),
                                 token.getSpec().getSeries());
                     }
                     if (isTokenExpired(token)) {
+                        log.info(
+                                "Remember-me token expired for user '{}', series '{}', lastUsed={}",
+                                token.getSpec().getUsername(),
+                                token.getSpec().getSeries(),
+                                token.getSpec().getLastUsed());
                         return Mono.error(new InvalidCookieException("Remember-me login has expired"));
                     }
                     return Mono.empty();
@@ -132,8 +150,9 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                     if (!Objects.equals(token.getSpec().getTokenValue(), presentedToken)) {
                         return Mono.just(token);
                     }
-                    log.debug(
-                            "Token value will be rotated for series '{}'",
+                    log.info(
+                            "Rotating remember-me token for user '{}', series '{}'",
+                            token.getSpec().getUsername(),
                             token.getSpec().getSeries());
                     token.getSpec().setPreviousTokenValue(presentedToken);
                     token.getSpec().setTokenValue(generateTokenData());
@@ -141,17 +160,24 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
                     return tokenRepository
                             .updateToken(token)
                             .doOnNext(updated -> {
-                                log.debug(
-                                        "Remember me token {} rotated successfully",
+                                log.info(
+                                        "Remember-me token rotated successfully for user '{}', series '{}'",
+                                        updated.getSpec().getUsername(),
                                         updated.getSpec().getSeries());
                                 addCookie(updated, exchange);
                             })
-                            .onErrorResume(
-                                    OptimisticLockingFailureException.class,
-                                    e -> tokenRepository
-                                            .getTokenForSeries(presentedSeries)
-                                            .doOnNext(fresh -> addCookie(fresh, exchange))
-                                            .defaultIfEmpty(token));
+                            .onErrorResume(OptimisticLockingFailureException.class, e -> {
+                                log.info(
+                                        "Optimistic locking failure during token rotation "
+                                                + "for user '{}', series '{}', "
+                                                + "falling back to fresh token",
+                                        token.getSpec().getUsername(),
+                                        token.getSpec().getSeries());
+                                return tokenRepository
+                                        .getTokenForSeries(presentedSeries)
+                                        .doOnNext(fresh -> addCookie(fresh, exchange))
+                                        .defaultIfEmpty(token);
+                            });
                 })
                 .flatMap(t -> getUserDetailsService().findByUsername(t.getSpec().getUsername()));
     }
@@ -159,12 +185,26 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
     private Mono<Void> validateDevice(ServerWebExchange exchange, RememberMeToken token) {
         return deviceService
                 .resolveCurrentDevice(exchange)
-                .switchIfEmpty(Mono.error(() -> new RememberMeAuthenticationException(
-                        "Unable to determine device for remember-me authentication")))
+                .switchIfEmpty(Mono.error(() -> {
+                    log.info(
+                            "Remember-me device validation failed for user '{}', series '{}': "
+                                    + "no device cookie found",
+                            token.getSpec().getUsername(),
+                            token.getSpec().getSeries());
+                    return new RememberMeAuthenticationException(
+                            "Unable to determine device for remember-me authentication");
+                }))
                 .filter(d -> Objects.equals(
                         d.getSpec().getRememberMeSeriesId(), token.getSpec().getSeries()))
-                .switchIfEmpty(Mono.error(() -> new RememberMeAuthenticationException(
-                        "Remember-me series ID does not match current device's series ID")))
+                .switchIfEmpty(Mono.error(() -> {
+                    log.info(
+                            "Remember-me device validation failed for user '{}', series '{}': "
+                                    + "device series ID does not match token series",
+                            token.getSpec().getUsername(),
+                            token.getSpec().getSeries());
+                    return new RememberMeAuthenticationException(
+                            "Remember-me series ID does not match current device's series ID");
+                }))
                 .then();
     }
 
@@ -190,7 +230,7 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
     @Override
     protected Mono<Void> onLoginSuccess(ServerWebExchange exchange, Authentication successfulAuthentication) {
         var username = successfulAuthentication.getName();
-        log.debug("Creating new persistent login for user {}", username);
+        log.info("Creating new remember-me persistent login for user '{}'", username);
         var t = new RememberMeToken();
         t.setMetadata(new Metadata());
         t.setSpec(new RememberMeToken.Spec());
@@ -204,12 +244,14 @@ public class PersistentTokenBasedRememberMeServices extends TokenBasedRememberMe
         return this.tokenRepository
                 .createNewToken(t)
                 .doOnNext(created -> {
-                    log.debug(
-                            "Remember-me token {} created successfully",
+                    log.info(
+                            "Remember-me token created for user '{}', series '{}'",
+                            username,
                             created.getSpec().getSeries());
                     addCookie(created, exchange);
                 })
-                .doOnError(e -> log.error("Remember-me token {} could not be created", seriesId, e))
+                .doOnError(e -> log.error(
+                        "Remember-me token could not be created for user '{}', series '{}'", username, seriesId, e))
                 .onErrorComplete()
                 .then();
     }

--- a/application/src/main/java/run/halo/app/security/authentication/rememberme/RememberMeTokenRevoker.java
+++ b/application/src/main/java/run/halo/app/security/authentication/rememberme/RememberMeTokenRevoker.java
@@ -2,6 +2,7 @@ package run.halo.app.security.authentication.rememberme;
 
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -17,6 +18,7 @@ import run.halo.app.infra.utils.ReactiveUtils;
  * @author guqing
  * @since 2.17.0
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RememberMeTokenRevoker {
@@ -26,6 +28,8 @@ public class RememberMeTokenRevoker {
     @Async
     @EventListener(PasswordChangedEvent.class)
     public void onPasswordChanged(PasswordChangedEvent event) {
+        log.info("Revoking all remember-me tokens for user '{}' due to password change", event.getUsername());
         tokenRepository.removeUserTokens(event.getUsername()).block(BLOCKING_TIMEOUT);
+        log.info("Revoked all remember-me tokens for user '{}'", event.getUsername());
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

为 remember-me token 生命周期中的关键决策点添加 `info` 级别日志，帮助排查 "记住我" 功能失效（token 被盗检测误判、凭证过期、设备不匹配等）问题。

具体修改：
- `PersistentTokenBasedRememberMeServices.processAutoLoginCookie`: 入口日志（series）、token 查找结果（user/lastUsed/tokenMatch）、cookie theft 检测详情、token 过期、token 轮换及乐观锁回退
- `PersistentTokenBasedRememberMeServices.onLoginSuccess`: token 创建升级为 info
- `PersistentTokenBasedRememberMeServices.validateDevice`: 设备校验失败时记录原因
- `RememberMeTokenRevoker`: 密码变更时 token 撤销前后记录
- `PersistentRememberMeTokenRepositoryImpl`: removeUserTokens / removeToken 记录

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

所有日志级别从 debug 升级为 info，确保在生产环境中默认可见。

#### Does this PR introduce a user-facing change?

```release-note
为 Remember-Me 认证流程添加 info 级别日志，便于排查"记住我"失效问题。
```